### PR TITLE
Various updates to Gradio demo and minor additions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@
 <a href='https://instantid.github.io/'><img src='https://img.shields.io/badge/Project-Page-green'></a>
 <a href='https://arxiv.org/abs/2401.07519'><img src='https://img.shields.io/badge/Technique-Report-red'></a>
 <a href='https://huggingface.co/papers/2401.07519'><img src='https://img.shields.io/static/v1?label=Paper&message=Huggingface&color=orange'></a> 
-<a href='https://huggingface.co/spaces/InstantX/InstantID'><img src='https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue'></a>
-[![ModelScope](https://img.shields.io/badge/modelscope-InstantID-blue)](https://modelscope.cn/studios/instantx/InstantID/summary)
 [![GitHub](https://img.shields.io/github/stars/InstantID/InstantID?style=social)](https://github.com/InstantID/InstantID)
+
+<a href='https://huggingface.co/spaces/InstantX/InstantID'><img src='https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue'></a>
+[![ModelScope](https://img.shields.io/badge/ModelScope-Studios-blue)](https://modelscope.cn/studios/instantx/InstantID/summary)
+[![Open in OpenXLab](https://cdn-static.openxlab.org.cn/app-center/openxlab_app.svg)](https://openxlab.org.cn/apps/detail/InstantX/InstantID)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -196,8 +196,9 @@ python gradio_demo/app.py
 ### Replicate Demo
 - [zsxkib/instant-id](https://replicate.com/zsxkib/instant-id)
 
-### RunPod Template
-- [InstantID RunPod Template](https://runpod.io/gsc?template=10apqooxnz&ref=2xxro4sy)
+### RunPod
+- [Pod Template](https://runpod.io/gsc?template=10apqooxnz&ref=2xxro4sy)
+- [Serverless Worker](https://github.com/ashleykleynhans/runpod-worker-instantid)
 
 ### Docker Image
 - [ashleykleynhans/instantid-docker](https://github.com/ashleykleynhans/instantid-docker)

--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ python gradio_demo/app.py
 ### Replicate Demo
 - [zsxkib/instant-id](https://replicate.com/zsxkib/instant-id)
 
+### RunPod Template
+- [InstantID RunPod Template](https://runpod.io/gsc?template=10apqooxnz&ref=2xxro4sy)
+
+### Docker Image
+- [ashleykleynhans/instantid-docker](https://github.com/ashleykleynhans/instantid-docker)
+
 ### WebUI
 - [Mikubill/sd-webui-controlnet](https://github.com/Mikubill/sd-webui-controlnet/discussions/2589)
 

--- a/gradio_demo/app.py
+++ b/gradio_demo/app.py
@@ -34,6 +34,7 @@ STYLE_NAMES = list(styles.keys())
 DEFAULT_STYLE_NAME = "Watercolor"
 DEFAULT_MODEL = "wangqixun/YamerMIX_v8"
 MODEL_DIRECTORY = "./models"
+CHECKPOINT_DIRECTORY = "./checkpoints"
 MAX_SIDE = 1280
 MIN_SIDE = 1024
 
@@ -48,27 +49,30 @@ elif torch.cuda.is_available():
 else:
     device = "cpu"
 
-# Download ControlNet checkpoint from Hugging Face Hub
-hf_hub_download(
-    repo_id="InstantX/InstantID",
-    filename="ControlNetModel/config.json",
-    local_dir="./checkpoints",
-    local_dir_use_symlinks=False
-)
-hf_hub_download(
-    repo_id="InstantX/InstantID",
-    filename="ControlNetModel/diffusion_pytorch_model.safetensors",
-    local_dir="./checkpoints",
-    local_dir_use_symlinks=False
-)
+# Download ControlNet checkpoint from Hugging Face Hub if the files do not already exist
+if not os.path.exists(os.path.join(CHECKPOINT_DIRECTORY, "ControlNetModel/config.json")):
+    hf_hub_download(
+        repo_id="InstantX/InstantID",
+        filename="ControlNetModel/config.json",
+        local_dir=CHECKPOINT_DIRECTORY,
+        local_dir_use_symlinks=False
+    )
+if not os.path.exists(os.path.join(CHECKPOINT_DIRECTORY, "ControlNetModel/diffusion_pytorch_model.safetensors")):
+    hf_hub_download(
+        repo_id="InstantX/InstantID",
+        filename="ControlNetModel/diffusion_pytorch_model.safetensors",
+        local_dir=CHECKPOINT_DIRECTORY,
+        local_dir_use_symlinks=False
+    )
 
-# Download IP-Adapter checkpoint from Hugging Face Hub
-hf_hub_download(
-    repo_id="InstantX/InstantID",
-    filename="ip-adapter.bin",
-    local_dir="./checkpoints",
-    local_dir_use_symlinks=False
-)
+# Download IP-Adapter checkpoint from Hugging Face Hub if the files do not already exist
+if not os.path.exists(os.path.join(CHECKPOINT_DIRECTORY, "ip-adapter.bin")):
+    hf_hub_download(
+        repo_id="InstantX/InstantID",
+        filename="ip-adapter.bin",
+        local_dir=CHECKPOINT_DIRECTORY,
+        local_dir_use_symlinks=False
+    )
 
 # Load face encoder
 app = FaceAnalysis(name="antelopev2", root='./', providers=["CUDAExecutionProvider", "CPUExecutionProvider"])

--- a/gradio_demo/app.py
+++ b/gradio_demo/app.py
@@ -41,6 +41,7 @@ else:
 
 STYLE_NAMES = list(styles.keys())
 DEFAULT_STYLE_NAME = "Watercolor"
+MODEL_PATH = "wangqixun/YamerMIX_v8"
 
 # Download checkpoints
 hf_hub_download(repo_id="InstantX/InstantID", filename="ControlNetModel/config.json", local_dir="./checkpoints")
@@ -238,7 +239,6 @@ def apply_style(style_name: str, positive: str, negative: str = "") -> tuple[str
 
 
 def generate_image(
-    model_path,
     face_image,
     pose_image,
     prompt,
@@ -251,6 +251,8 @@ def generate_image(
     seed,
     progress=gr.Progress(track_tqdm=True)
         ):
+
+    global MODEL_PATH
 
     if face_image is None:
         raise gr.Error(f"Cannot find any input face image! Please upload the face image")
@@ -294,12 +296,12 @@ def generate_image(
     generator = torch.Generator(device=device).manual_seed(seed)
 
     logging.info("Start inference...")
-    logging.debug(f"Model Path: {model_path}")
+    logging.debug(f"Model Path: {MODEL_PATH}")
     logging.debug(f"Prompt: {prompt}")
     logging.debug(f"Negative Prompt: {negative_prompt}")
-    logging.info(f"Loading Pipeline for: {model_path}")
+    logging.info(f"Loading Pipeline for: {MODEL_PATH}")
 
-    pipe = get_pipeline(model_path)
+    pipe = get_pipeline(MODEL_PATH)
     pipe.set_ip_adapter_scale(adapter_strength_ratio)
     images = pipe(
         prompt=prompt,
@@ -518,6 +520,8 @@ if __name__ == "__main__":
     launch_kwargs = {}
     launch_kwargs["server_name"] = args.listen
 
+    if args.model_path != MODEL_PATH:
+        MODEL_PATH = args.model_path
     if args.username and args.password:
         launch_kwargs["auth"] = (args.username, args.password)
     if args.server_port:

--- a/gradio_demo/app.py
+++ b/gradio_demo/app.py
@@ -42,13 +42,18 @@ else:
 STYLE_NAMES = list(styles.keys())
 DEFAULT_STYLE_NAME = "Watercolor"
 
+# Download checkpoints
+hf_hub_download(repo_id="InstantX/InstantID", filename="ControlNetModel/config.json", local_dir="./checkpoints")
+hf_hub_download(repo_id="InstantX/InstantID", filename="ControlNetModel/diffusion_pytorch_model.safetensors", local_dir="./checkpoints")
+hf_hub_download(repo_id="InstantX/InstantID", filename="ip-adapter.bin", local_dir="./checkpoints")
+
 # Load face encoder
-app = FaceAnalysis(name='antelopev2', root='./', providers=['CUDAExecutionProvider', 'CPUExecutionProvider'])
+app = FaceAnalysis(name="antelopev2", root='./', providers=["CUDAExecutionProvider", "CPUExecutionProvider"])
 app.prepare(ctx_id=0, det_size=(640, 640))
 
 # Path to InstantID models
-face_adapter = f'./checkpoints/ip-adapter.bin'
-controlnet_path = f'./checkpoints/ControlNetModel'
+face_adapter = f"./checkpoints/ip-adapter.bin"
+controlnet_path = f"./checkpoints/ControlNetModel"
 
 # Load ControlNet
 controlnet = ControlNetModel.from_pretrained(controlnet_path, torch_dtype=torch_dtype)

--- a/gradio_demo/app.py
+++ b/gradio_demo/app.py
@@ -52,19 +52,22 @@ else:
 hf_hub_download(
     repo_id="InstantX/InstantID",
     filename="ControlNetModel/config.json",
-    local_dir="./checkpoints"
+    local_dir="./checkpoints",
+    local_dir_use_symlinks=False
 )
 hf_hub_download(
     repo_id="InstantX/InstantID",
     filename="ControlNetModel/diffusion_pytorch_model.safetensors",
-    local_dir="./checkpoints"
+    local_dir="./checkpoints",
+    local_dir_use_symlinks=False
 )
 
 # Download IP-Adapter checkpoint from Hugging Face Hub
 hf_hub_download(
     repo_id="InstantX/InstantID",
     filename="ip-adapter.bin",
-    local_dir="./checkpoints"
+    local_dir="./checkpoints",
+    local_dir_use_symlinks=False
 )
 
 # Load face encoder

--- a/gradio_demo/requirements.txt
+++ b/gradio_demo/requirements.txt
@@ -1,6 +1,6 @@
 diffusers==0.25.1
 torch==2.0.1
-torchvision==0.15.1
+torchvision==0.15.2
 transformers==4.37.1
 accelerate
 safetensors

--- a/gradio_demo/requirements.txt
+++ b/gradio_demo/requirements.txt
@@ -1,7 +1,7 @@
-diffusers==0.25.0
-torch==2.0.0
+diffusers==0.25.1
+torch==2.0.1
 torchvision==0.15.1
-transformers==4.30.1
+transformers==4.37.1
 accelerate
 safetensors
 einops

--- a/gradio_demo/style_template.py
+++ b/gradio_demo/style_template.py
@@ -44,6 +44,106 @@ style_list = [
         "prompt": "line art drawing {prompt} . professional, sleek, modern, minimalist, graphic, line art, vector graphics",
         "negative_prompt": "anime, photorealistic, 35mm film, deformed, glitch, blurry, noisy, off-center, deformed, cross-eyed, closed eyes, bad anatomy, ugly, disfigured, mutated, realism, realistic, impressionism, expressionism, oil, acrylic",
     },
+        {
+        "name": "Art Nouveau",
+        "prompt": "Art Nouveau style, {prompt}, organic forms, curvilinear lines, elegant, nature-inspired, intricate patterns, flowing designs, soft colors",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, brutalism, geometric, harsh lines, noisy",
+    },
+    {
+        "name": "Cubism",
+        "prompt": "cubist painting, {prompt}, abstract, geometric shapes, fragmented objects, multiple viewpoints, bold lines, reduced colors, Pablo Picasso inspired",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, photorealistic, smooth, flowing, noisy",
+    },
+    {
+        "name": "Minimalism",
+        "prompt": "minimalist art, {prompt}, simple, clean lines, monochrome, negative space, minimal detail, geometric shapes, modern, sophisticated",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, baroque, cluttered, over-detailed, noisy",
+    },
+    {
+        "name": "Baroque",
+        "prompt": "baroque style, {prompt}, grandeur, drama, contrast, rich colors, intense lighting, ornate, Caravaggio inspired, emotional, detailed",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, minimalist, flat, dull, noisy",
+    },
+    {
+        "name": "Expressionism",
+        "prompt": "expressionist art, {prompt}, emotional, distorted, exaggerated, vivid colors, dynamic brushstrokes, subjective perspective, impactful",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, photorealism, bland, underwhelming, noisy",
+    },
+    {
+        "name": "Digital Glitch",
+        "prompt": "digital glitch art, {prompt}, corrupted image, tech-inspired, vibrant, surreal, abstract, pixelated, data moshing, futuristic",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, classical, realistic, smooth, noiseless",
+    },
+    {
+        "name": "Psychedelic",
+        "prompt": "psychedelic art, {prompt}, vivid colors, hallucinatory patterns, surreal, fluid shapes, trippy, 1960s style, kaleidoscopic, vibrant",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, monochrome, simplistic, noiseless",
+    },
+    {
+        "name": "Victorian",
+        "prompt": "Victorian style, {prompt}, elegant, ornate, romantic, historical, detailed patterns, rich textures, sophisticated, vintage",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, modern, minimalist, plain, noisy",
+    },
+    {
+        "name": "Graffiti",
+        "prompt": "graffiti art, {prompt}, urban, street style, bold colors, spray paint, tagging, hip-hop culture, dynamic, expressive, contemporary",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, classical, fine art, noiseless, smooth",
+    },
+    {
+        "name": "Ukiyo-e",
+        "prompt": "Ukiyo-e style, {prompt}, Japanese woodblock print, flat color areas, bold outlines, historical scenes, nature, Edo period, traditional",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, 3D, photorealistic, modern, noisy",
+    },
+        {
+        "name": "Retro Futurism",
+        "prompt": "retro futurism, {prompt}, vibrant colors, geometric shapes, streamline design, 1950s and 1960s style, optimistic, space-age, visionary, neon lighting, bold typography",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, medieval, deformed, glitch, blurry, noisy",
+    },
+    {
+        "name": "Steampunk",
+        "prompt": "steampunk style, {prompt}, Victorian era, industrial, mechanical gears, brass and copper, steam engines, intricate details, fantastical machines, sepia tones",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, neon, futuristic, blurry, noisy",
+    },
+    {
+        "name": "Cyberpunk",
+        "prompt": "cyberpunk aesthetic, {prompt}, neon lights, urban dystopia, futuristic, high-tech, low-life, cybernetics, dark and gritty, vivid colors, digital world",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, medieval, steampunk, blurry, noisy",
+    },
+    {
+        "name": "Impressionist",
+        "prompt": "impressionist style painting, {prompt}, vibrant, light brushstrokes, open composition, emphasis on light in its changing qualities, movement, ordinary subject matter",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, photorealistic, 35mm film, deformed, glitch, low contrast, noisy",
+    },
+    {
+        "name": "Art Deco",
+        "prompt": "art deco style, {prompt}, glamorous, elegant, functional, geometric patterns, bold colors, sleek lines, chrome, glass, shiny fabrics",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, rustic, medieval, deformed, glitch, noisy",
+    },
+    {
+        "name": "Fantasy",
+        "prompt": "fantasy style, {prompt}, mythical creatures, enchanted forests, magic elements, dreamlike landscapes, vibrant colors, detailed, imaginative",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, photorealistic, 35mm film, deformed, glitch, low contrast, noisy",
+    },
+    {
+        "name": "Gothic",
+        "prompt": "gothic style, {prompt}, dark and moody, gothic architecture, medieval elements, dramatic lighting, somber tones, intricate details, mysterious atmosphere",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, neon, futuristic, blurry, noisy",
+    },
+    {
+        "name": "Pop Art",
+        "prompt": "pop art style, {prompt}, bold colors, mass culture, comic style, ironic, whimsical, repetition of images, bright, high contrast",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, medieval, steampunk, blurry, noisy",
+    },
+    {
+        "name": "Surrealism",
+        "prompt": "surrealist style, {prompt}, dreamlike, bizarre, irrational, abstract, imaginative, distorted reality, vivid, unexpected juxtapositions",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, photorealistic, 35mm film, deformed, glitch, low contrast, noisy",
+    },
+    {
+        "name": "Abstract",
+        "prompt": "abstract style, {prompt}, non-representational, shapes, forms, colors, lines, dynamic, modern, expressive, non-figurative, bold",
+        "negative_prompt": "(lowres, low quality, worst quality:1.2), (text:1.2), watermark, anime, photorealistic, 35mm film, deformed, glitch, low contrast, noisy",
+    },
 ]
 
 styles = {k["name"]: (k["prompt"], k["negative_prompt"]) for k in style_list}


### PR DESCRIPTION
* Refactored Gradio demo to move out nested the functions.
* Added code to download the ControlNet and IP-Adapter checkpoints from Huggingface Hub to the Gradio demo.
* Added support for machines with low and medium VRAM by adjusting the resolution to the Gradio demo (implemented by command line arguments).
* Added attention slicing for MPS to the Gradio demo.
* Added a dropdown to change the model path and a refresh button to load the list of models from disk in the Gradio demo.
* Clear the CUDA cache after generation to free up VRAM in the Gradio demo.
* Added additional styles to the style template.
* Bumped diffusers, torch, torchvision and transformers versions in requirements.
* Added RunPod Pod Template to README.
* Added RunPod Serverless Worker to README.
* Added Docker Image to README.